### PR TITLE
Fixed makefile to check TRT version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,15 @@ CCSOURCES += $(wildcard edge-impulse-sdk/tensorflow/lite/kernels/*.cc) $(wildcar
 endif # not USE_FULL_TFLITE and not USE_AKIDA
 
 ifeq (${TARGET_JETSON_NANO},1)
+TENSORRT_VERSION=$(strip $(shell dpkg -l | grep '^ii' | grep libnvinfer[0-9] | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'))
+$(info TENSORRT_VERSION is ${TENSORRT_VERSION})
+ifeq (${TENSORRT_VERSION},8)
 LDFLAGS += tflite/linux-jetson-nano/libei_debug.a -L/usr/local/cuda-10.2/targets/aarch64-linux/lib/ -lcudart -lnvinfer -lnvonnxparser  -Wl,--warn-unresolved-symbols,--unresolved-symbols=ignore-in-shared-libs
-ifeq (,$(wildcard ./tflite/linux-jetson-nano/libcudart.so))
-$(error Missing shared libraries for TensorRT. Install them via `sh ./tflite/linux-jetson-nano/download.sh`)
-endif
+else ifeq (${TENSORRT_VERSION},7)
+LDFLAGS += tflite/linux-jetson-nano/libei_debug7.a -L/usr/local/cuda-10.2/targets/aarch64-linux/lib/ -lcudart -lnvinfer -lnvonnxparser  -Wl,--warn-unresolved-symbols,--unresolved-symbols=ignore-in-shared-libs
+else
+$(error Invalid TensorRT version - supported versions are 7 and 8.)
+endif # TENSORRT_VERSION
 endif # TARGET_JETSON_NANO
 
 ifeq (${APP_CUSTOM},1)

--- a/tflite/linux-jetson-nano/README.md
+++ b/tflite/linux-jetson-nano/README.md
@@ -4,6 +4,6 @@ The `libei_debug.a` file was built from: https://github.com/edgeimpulse/TensorRT
 $ sh docker/build.sh --file docker/ubuntu-cross-aarch64.Dockerfile --tag tensorrt --cuda 10.2
 ```
 
-You can find the library in `/workspace/TensorRT/build/out/libei_debug.a` in the container. It is also automatically copied after succesful build to the /docker folder.
+You can find the library in `/workspace/TensorRT/build/out/libei_debug.a` in the container. It is also automatically copied after a successful build to the /docker folder.
 
-`libei_debug.a` is a version of the library built with TensorRT 7.x.
+`libei_debug7.a` is a version of the library built with TensorRT 7.x.


### PR DESCRIPTION
We have libei_debug for TRT 7 and TRT 8. In this PR we add the TRT version check and use the corresponding libei_debug version.